### PR TITLE
try to fix release drafter automation

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -51,7 +51,7 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -62,20 +62,24 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: version
-        id: version
+      - name: Get version
+        id: get_version
         run: |
-          tag=${GITHUB_REF/refs\/tags\//}
-          version=${tag#v}
-          major=${version%%.*}
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
-          echo "version=${version}" >> $GITHUB_OUTPUT
-          echo "major=${major}" >> $GITHUB_OUTPUT
+          echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          if [[ ${{ contains(github.ref_name, '-beta.rc') }} == 'true' ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
 
-      - uses: release-drafter/release-drafter@v6
+      - name: Create Release and Changelog
+        id: create-release
+        uses: release-drafter/release-drafter@v6
         with:
-          version: ${{ steps.version.outputs.version }}
-          publish: true
+          tag: ${{ steps.get_version.outputs.version }}
+          version: ${{ steps.get_version.outputs.version }}
+          prerelease: ${{ steps.get_version.outputs.prerelease }}
+          publish: true # ensures release is not marked as draft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
I borrowed this from "paperless-ngx".  Slightly different way of referring to tag and seems to work for them and is less complex than what I had before which seemed not to work.  Was giving error like:  "refs/tags/v0.9.4 is not supported as release target, falling back to default branch" in the logs.