### PR TITLE
Enable Python 3.14 in CI and PyPI wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,10 @@ jobs:
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           - { python: "3.13", os: "ubuntu-latest", session: "tests" }
-          #- { python: "3.14", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.14", os: "ubuntu-latest", session: "tests" }
           #- { python: "3.12", os: "windows-latest", session: "tests" }
           - { python: "3.13", os: "macos-latest", session: "tests" }
+          - { python: "3.14", os: "macos-latest", session: "tests" }
           - { python: "3.10", os: "macos-14", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "typeguard" }
           #- { python: "3.12", os: "ubuntu-latest", session: "docs" }

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,7 +13,7 @@ from nox_uv import session
 options.default_venv_backend = "uv"
 
 package = "dipoleq"
-python_versions = ["3.13", "3.12", "3.11", "3.10"]
+python_versions = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 options.sessions = (
     "pre-commit",
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [
@@ -112,7 +113,7 @@ testpaths = ["python/tests"]
 
 
 [tool.cibuildwheel]
-build = "cp31{0,1,2,3}-*"
+build = "cp31{0,1,2,3,4}-*"
 test-command = "pytest {project}"
 test-groups = ["test"]
 test-skip = ["*_universal2:arm64", "*win*"] # skip windows


### PR DESCRIPTION
## Summary

Adds Python 3.14 to the test matrix and release wheels:

- **cibuildwheel**: `build = "cp31{0,1,2,3,4}-*"` so cp314 wheels ship to PyPI
- **classifiers**: add `Programming Language :: Python :: 3.14`
- **noxfile**: add 3.14 to `python_versions`; the existing `_should_install_imas` guard already skips the imas group on 3.14 (imas-python doesn't support it yet)
- **tests.yml**: enable the previously commented-out ubuntu 3.14 row and add a macos-latest 3.14 row

## Stacked on #67

Based on `chore/update-deps` because local verification on arm64 needs the per-arch macOS deployment target fix from that PR (otherwise the 3.14 wheel gets an invalid `macosx_10_15_arm64` tag). GitHub will retarget this PR to `main` automatically when #67 merges.

## Testing

- `nox -s tests-3.14` locally (macOS arm64): builds the extension under CPython 3.14 and passes — 19 passed, 2 skipped (imas, by design)
- `uv lock --check` passes
- pre-commit passes on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)