### PR TITLE
Modernize release-drafter config for v7

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,28 +1,51 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: ":boom: Breaking Changes"
-    label: "breaking"
+    semver-increment: major
+    when:
+      label: "breaking"
   - title: ":rocket: Features"
-    label: "enhancement"
+    semver-increment: minor
+    when:
+      label: "enhancement"
   - title: ":fire: Removals and Deprecations"
-    label: "removal"
+    semver-increment: minor
+    when:
+      label: "removal"
   - title: ":beetle: Fixes"
-    label: "bug"
+    when:
+      label: "bug"
   - title: ":racehorse: Performance"
-    label: "performance"
+    when:
+      label: "performance"
   - title: ":rotating_light: Testing"
-    label: "testing"
+    when:
+      label: "testing"
   - title: ":construction_worker: Continuous Integration"
-    label: "ci"
+    when:
+      labels:
+        - "ci"
+        - "github_actions"
   - title: ":books: Documentation"
-    label: "documentation"
+    when:
+      label: "documentation"
   - title: ":hammer: Refactoring"
-    label: "refactoring"
+    when:
+      label: "refactoring"
   - title: ":lipstick: Style"
-    label: "style"
+    when:
+      label: "style"
   - title: ":package: Dependencies"
-    labels:
-      - "dependencies"
-      - "build"
+    when:
+      labels:
+        - "dependencies"
+        - "build"
+  # everything else still bumps the patch version
+  - type: "version-resolver"
+    semver-increment: "patch"
+change-template: "- $TITLE (#$NUMBER) $AUTHORS"
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 template: |
   ## Changes
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,13 +5,6 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize, labeled]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize, labeled]
 
 permissions:
   contents: read
@@ -21,21 +14,10 @@ jobs:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
-
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v7
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Publishing v0.11.1 surfaced a wall of release-drafter warnings: v7 deprecated `categories[*].label`/`labels` (one warning per category, per run). This rebuilds `.github/release-drafter.yml` on the current upstream example config ([release-drafter#1558](https://github.com/release-drafter/release-drafter/pull/1558)) rather than patching the old hypermodern-template boilerplate, and aligns the workflow with the upstream recommended one.

### Why not the upstream default verbatim

The upstream example categorizes on `feature`/`fix`/`bugfix`/`chore` labels, which this repo doesn't have — `.github/labels.yml` defines the hypermodern set (`breaking`, `enhancement`, `bug`, `dependencies`, ...) that Dependabot and existing PRs actually carry. Installing the default as-is would leave nearly every PR uncategorized. So this keeps the repo's labels and section titles, and adopts the new config features:

- **`when` conditions** for all categories (kills the deprecation warnings)
- **Version resolution**: `breaking` → major, `enhancement`/`removal` → minor, catch-all `version-resolver` → patch, so the draft release suggests the next version automatically
- **Upstream default `change-template`** (`- $TITLE (#$NUMBER) $AUTHORS`) with title escapes
- Explicit `name-template`/`tag-template` matching the existing plain `vX.Y.Z` release naming
- `github_actions` label added to the CI category (Dependabot applies it to Actions bumps)
- Kept `exclude-contributors: Dependabot`

### Workflow cleanup

The `pull_request`/`pull_request_target` triggers existed solely for the autolabeler feature, which this repo doesn't configure; on every PR they just produced a forced dry-run with an "ephemeral merge commit" warning. The workflow now matches the upstream recommendation: push-to-main only, `pull-requests` permission narrowed to `read`.

## Testing

- YAML validates (pre-commit `check-yaml`)
- The release-drafter run against the new config on this branch completed with **zero deprecation warnings** (previously 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)